### PR TITLE
Fix installation of gauge plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ LABEL maintainer="John Boyes <john@agilepathway.co.uk>"
 COPY scripts /usr/local/bin/
 
 USER root
-RUN    chmod 700 /usr/local/bin/install-chrome.sh \
-    && chmod 700 /usr/local/bin/install-gauge.sh \
+RUN    chmod 755 /usr/local/bin/install-chrome.sh \
+    && chmod 755 /usr/local/bin/install-gauge.sh \
+    && chmod 755 /usr/local/bin/install-gauge-plugins.sh \
     && install-chrome.sh \
     && install-gauge.sh
 USER circleci
+RUN install-gauge-plugins.sh

--- a/scripts/install-gauge-plugins.sh
+++ b/scripts/install-gauge-plugins.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+gauge install html-report
+gauge install screenshot
+gauge install xml-report
+gauge install js

--- a/scripts/install-gauge.sh
+++ b/scripts/install-gauge.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 curl -SsL https://downloads.gauge.org/stable | sh
-gauge install html-report
-gauge install screenshot
-gauge install xml-report
 
 # test/verify installation
 if gauge --version; then


### PR DESCRIPTION
The plugins are now installed so that the circleci user can access them.
This speeds up the build as it means they are now pre-installed before the end to end tests run.
Also installed the js plugin which was missing.