### PR TITLE
Add immutable docker tag for consumers to pin to

### DIFF
--- a/scripts/tag-and-conditionally-publish-image.sh
+++ b/scripts/tag-and-conditionally-publish-image.sh
@@ -10,9 +10,12 @@ GAUGE_TAG="GAUGE-$GAUGE_VERSION"
 GIT_TAG="GIT-COMMIT-${CIRCLE_SHA1}"
 NODE_VERSION=13.12
 NODE_TAG="NODE-${NODE_VERSION}"
-# Using the Gauge version as the semantic version of the image, as that is what CircleCI do
+# Tag Gauge version as the semantic version of the image, as that is what CircleCI do
 # for their base images: https://circleci.com/docs/2.0/circleci-images/#best-practices
 docker tag "$IMAGE_NAME:latest" "$IMAGE_NAME:$GAUGE_VERSION"
+# Also tag the Gauge version and the circle build together so that consumers can pin to an 
+# idempotent image
+docker tag "$IMAGE_NAME:latest" "$IMAGE_NAME:$GAUGE_VERSION"-"$CIRCLECI_TAG"
 docker tag "$IMAGE_NAME:latest" "$IMAGE_NAME:$CHROME_TAG"
 docker tag "$IMAGE_NAME:latest" "$IMAGE_NAME:$CIRCLECI_TAG"
 docker tag "$IMAGE_NAME:latest" "$IMAGE_NAME:$GAUGE_TAG"


### PR DESCRIPTION
The new tag is the semantic version (i.e. the gauge version), followed
by the circleci tag - which includes the circleci build number.
Because the build number is unique for every build, it means that
consumers can pin to this tag knowing that the image will not change
in the future.

This also means that consumers don't need to pin to the digest to get
an immutable image.  The circleci build number is more meaningful than
the digest, making it easier to correlate data when needed.

See these articles on the dangers of mutable tags:
- https://stevelasker.blog/2018/03/01/docker-tagging-best-practices-for-tagging-and-versioning-docker-images/
- https://renovate.whitesourcesoftware.com/blog/overcoming-dockers-mutable-image-tags/
- https://medium.com/sroze/why-i-think-we-should-all-use-immutable-docker-images-9f4fdcb5212f