### PR TITLE
Store docker tags as build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,3 +43,6 @@ jobs:
       - run:
           name: Publish Docker Image to Docker Hub
           command: ./scripts/tag-and-conditionally-publish-image.sh
+      - store_artifacts:
+          path: /tmp/tags
+          destination: docker/tags

--- a/scripts/tag-and-conditionally-publish-image.sh
+++ b/scripts/tag-and-conditionally-publish-image.sh
@@ -21,6 +21,8 @@ docker tag "$IMAGE_NAME:latest" "$IMAGE_NAME:$CIRCLECI_TAG"
 docker tag "$IMAGE_NAME:latest" "$IMAGE_NAME:$GAUGE_TAG"
 docker tag "$IMAGE_NAME:latest" "$IMAGE_NAME:$GIT_TAG"
 docker tag "$IMAGE_NAME:latest" "$IMAGE_NAME:$NODE_TAG"
+echo "Created the following tags:"
+docker images "$IMAGE_NAME" --format="{{ .Tag }}" | tee -a  "/tmp/tags"
 if [ "${CIRCLE_BRANCH}" == "master" ]; then
       docker push "$IMAGE_NAME"
 fi


### PR DESCRIPTION
Might be better to store them in a format like json or yml (probably json) - can do that in a future PR.  Could do this after converting the bash scripts to go.