### PR TITLE
Store the Docker digest as a build artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,3 +53,6 @@ jobs:
       - store_artifacts:
           path: /tmp/tags
           destination: docker/tags
+      - store_artifacts:
+          path: /tmp/digest
+          destination: docker/digest

--- a/scripts/tag-and-conditionally-publish-image.sh
+++ b/scripts/tag-and-conditionally-publish-image.sh
@@ -25,4 +25,5 @@ echo "Created the following tags:"
 docker images "$IMAGE_NAME" --format="{{ .Tag }}" | tee -a  "/tmp/tags"
 if [ "${CIRCLE_BRANCH}" == "master" ]; then
       docker push "$IMAGE_NAME"
+      docker images "$IMAGE_NAME" --format="{{ .Digest }}" | tee -a  "/tmp/digest"
 fi


### PR DESCRIPTION
This will make it easier to correlate data when needed.

Closes #5 