### PR TITLE
Pre-install Taiko

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ USER root
 RUN    chmod 755 /usr/local/bin/install-chrome.sh \
     && chmod 755 /usr/local/bin/install-gauge.sh \
     && chmod 755 /usr/local/bin/install-gauge-plugins.sh \
+    && chmod 755 /usr/local/bin/install-taiko.sh \
     && install-chrome.sh \
     && install-gauge.sh
 USER circleci
-RUN install-gauge-plugins.sh
+RUN    install-gauge-plugins.sh \
+    && install-taiko.sh

--- a/scripts/install-taiko.sh
+++ b/scripts/install-taiko.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# To use this globally installed taiko, consumers should navigate to the directory
+# where the local version would be installed, and run `npm link taiko`.
+# This speeds up the build by avoiding having to install Taiko each time, and means
+# there are fewer moving parts during the build.
+# See:
+# https://github.com/getgauge/taiko/issues/326#issuecomment-452584249
+# https://github.com/getgauge/gauge-js/issues/174#issuecomment-435271044
+
+npm config set prefix ~/.npm-global
+npm install -g taiko --unsafe-perm --allow-root


### PR DESCRIPTION
Installing Taiko globally. Consumers should navigate to their directory
where the local version would be installed, and run `npm link taiko` to
link to the global version.

See:
https://github.com/getgauge/taiko/issues/326#issuecomment-452584249
https://github.com/getgauge/gauge-js/issues/174#issuecomment-435271044