### PR TITLE
Fix Chrome installation

### DIFF
--- a/scripts/install-chrome.sh
+++ b/scripts/install-chrome.sh
@@ -73,6 +73,7 @@ else
     libdbus-1-3 \
     libgdk-pixbuf2.0-0 \
     libglib2.0-0 \
+    libgbm1 \
     libgtk-3-0 \
     libnspr4 \
     libnss3 \


### PR DESCRIPTION
The installation of Chrome had started to fail suddenly, saying:

```
google-chrome-stable depends on libgbm1 (>= 8.1~0); however:
Package libgbm1 is not installed.
```

Fix by installing libgbm1