### PR TITLE
Automatically create a Go modules release on git tag push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,15 @@ workflows:
                 at: .
             - run: sudo cp -r go-scripts/bin/* /usr/local/bin/
           tag_after_build: $(docker-tags -v)
+  release:
+    jobs:
+      - release:
+          # Only run on git tag pushes
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
 
             
 jobs:
@@ -59,3 +68,10 @@ jobs:
           root: .
           paths:
             - go-scripts/bin/*
+
+  release:
+    docker:
+      - image: circleci/golang:1.14
+    steps:
+      - checkout
+      - run: curl -sL https://git.io/goreleaser | bash


### PR DESCRIPTION
[Go modules dictates](https://blog.golang.org/publishing-go-modules) that we should publish a new [semantic version](https://semver.org/) for every trunk commit (even if our module is not intended for use by others).  This is a good thing.

Use [GoReleaser](https://goreleaser.com/ci/) to create a new release every time a Git tag is pushed to GitHub.

The current workflow is that after a pull request has been merged to master, and the CircleCI build on master has passed, we then manually create a new Git tag with our new semantic version, and push it to GitHub.  This then automatically triggers the creation of the release.

An improvement on this workflow would be to indicate the release type in the pull request (e.g. major, minor, patch), and then automatically create the tag in the CircleCI build on master.