### PR TITLE
Ensure release job is visible in CircleCI UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,6 @@ workflows:
                 at: .
             - run: sudo cp -r go-scripts/bin/* /usr/local/bin/
           tag_after_build: $(docker-tags -v)
-  release:
-    jobs:
       - release:
           # Only run on git tag pushes
           filters:


### PR DESCRIPTION
The release job looked to be triggering ok on git tag push, as it
should, but it was not displaying on the CircleCI UI.

Instead there was a build saying "No workflow", which could not be
navigated to.

Fixed by running the release job in the same workflow as the other
jobs.

This could be a bug in CircleCI, but it’s straightforward to move the job so that there’s just one workflow.