### PR TITLE
Set up goreleaser config properly

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,7 @@
+project_name: cimg-gauge
+build:
+  skip: true
+release:
+  github:
+  prerelease: auto
+  


### PR DESCRIPTION
As there is no `main` package (because our Go module is a mage project), we skip the building of an executable binary, as per:
https://github.com/goreleaser/goreleaser/pull/1419