### PR TITLE
Pin the semver-release-action to a fixed version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Tag 
-        uses: K-Phoen/semver-release-action@master
+        uses: K-Phoen/semver-release-action@v1.3.1
         with:
           release_branch: master
           release_strategy: tag


### PR DESCRIPTION
Pinned to 1.3.1, which was the latest version in master that was being
used successfully before this change:
https://github.com/K-Phoen/semver-release-action/releases/tag/v1.3.1