### PR TITLE
Use 0.5.3 Docker orb with tagging errors fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   shellcheck: circleci/shellcheck@1.3.15
-  docker: agilepathway/docker@0.5.2
+  docker: agilepathway/docker@0.5.3
 
 executors:
   go:


### PR DESCRIPTION
The 0.5.3 orb fixes #44, where errors in the Docker tagging were being suppressed.