### PR TITLE
Refactor go tagging and version lookup

### DIFF
--- a/internal/docker/executor.go
+++ b/internal/docker/executor.go
@@ -2,14 +2,12 @@ package docker
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/magefile/mage/sh"
 )
 
-func execute(command string) string {
-	imageName := os.Getenv("IMAGE_NAME")
-	commandOutput, error := sh.Output("docker", "run", "--rm", "-i", imageName, "bash", "-c", command)
+func execute(image string, command string) string {
+	commandOutput, error := sh.Output("docker", "run", "--rm", "-i", image, "bash", "-c", command)
 
 	if error != nil {
 		panic(fmt.Sprintf("Error executing docker command: %s", error))

--- a/internal/docker/image.go
+++ b/internal/docker/image.go
@@ -1,0 +1,19 @@
+package docker
+
+type image struct {
+	name          string
+	gaugeVersion  string
+	chromeVersion string
+	goVersion     string
+	nodeVersion   string
+	taikoVersion  string
+}
+
+func newImage(name string) *image {
+	return &image{name,
+		gaugeVersion(name),
+		chromeVersion(name),
+		goVersion(name),
+		nodeVersion(name),
+		taikoVersion(name)}
+}

--- a/internal/docker/tags.go
+++ b/internal/docker/tags.go
@@ -9,40 +9,55 @@ import (
 	"strings"
 )
 
+// TagsForImage returns the list of Docker tags which the image should then be tagged with.
+// The list includes version numbers of the key software installed on the image.
+func TagsForImage(imageName string) string {
+	image := newImage(imageName)
+	return image.tags()
+}
+
 // Tags returns the Docker tags which the Docker image should then be tagged with
-func Tags() string {
-	tags := []string{gaugeVersion(), gaugeVersionAndCircleTag(), gaugeTag(), chromeTag(), goTag(), nodeTag(), taikoTag()}
+func (i image) tags() string {
+	tags := []string{
+		i.gaugeVersion,
+		i.gaugeVersionAndCircleTag(),
+		i.gaugeTag(),
+		i.chromeTag(),
+		i.goTag(),
+		i.nodeTag(),
+		i.taikoTag()}
+
 	return strings.Join(tags, ",")
 }
 
-func gaugeVersionAndCircleTag() string {
-	return fmt.Sprintf("%s-%s", gaugeVersion(), circleCIBuildTag())
+func (i image) gaugeVersionAndCircleTag() string {
+	return fmt.Sprintf("%s-%s", i.gaugeVersion, i.circleCIBuildTag())
 }
 
-func gaugeTag() string {
-	return fmt.Sprintf("GAUGE-%s", gaugeVersion())
+func (i image) gaugeTag() string {
+	return fmt.Sprintf("GAUGE-%s", i.gaugeVersion)
 }
 
-func circleCIBuildTag() string {
-	return fmt.Sprintf("CIRCLECI-%s", circleCIBuildNumber())
+func (i image) circleCIBuildTag() string {
+	return fmt.Sprintf("CIRCLECI-%s", i.circleCIBuildNumber())
 }
 
-func circleCIBuildNumber() string {
+func (i image) circleCIBuildNumber() string {
 	return os.Getenv("CIRCLE_BUILD_NUM")
 }
 
-func chromeTag() string {
-	return fmt.Sprintf("CHROME-%s", chromeVersion())
+func (i image) chromeTag() string {
+	return fmt.Sprintf("CHROME-%s", i.chromeVersion)
 }
 
-func goTag() string {
-	return fmt.Sprintf("GO-%s", goVersion())
+func (i image) goTag() string {
+	return fmt.Sprintf("GO-%s", i.goVersion)
 }
 
-func nodeTag() string {
-	return fmt.Sprintf("NODE-%s", nodeVersion())
+func (i image) nodeTag() string {
+	return fmt.Sprintf("NODE-%s", i.nodeVersion)
 }
 
-func taikoTag() string {
-	return fmt.Sprintf("TAIKO-%s", taikoVersion())
+func (i image) taikoTag() string {
+	return fmt.Sprintf("TAIKO-%s", i.taikoVersion)
 }

--- a/internal/docker/tags_test.go
+++ b/internal/docker/tags_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestTags(t *testing.T) {
-	checkDockerTags(t, []byte(Tags()))
+	actualTags := TagsForImage("TODO: more meaningful name")
+	checkDockerTags(t, []byte(actualTags))
 }
 
 func checkDockerTags(t *testing.T, actual []byte) {

--- a/internal/docker/version.go
+++ b/internal/docker/version.go
@@ -11,17 +11,17 @@ type softwareVersion struct {
 	dummy     string
 }
 
-func (sv softwareVersion) findAndTrim() string {
-	verboseVersion := sv.findVerbose(sv.command)
+func (sv softwareVersion) findAndTrim(image string) string {
+	verboseVersion := sv.findVerbose(image, sv.command)
 	return sv.trim(verboseVersion)
 }
 
-func (sv softwareVersion) findVerbose(command string) string {
+func (sv softwareVersion) findVerbose(image, command string) string {
 	if doesEnvVarExist("INTEGRATION_TEST") {
 		return sv.dummy
 	}
 
-	return execute(command)
+	return execute(image, command)
 }
 
 func (sv softwareVersion) trim(verbose string) string {
@@ -34,7 +34,7 @@ func doesEnvVarExist(envVar string) bool {
 	return exists
 }
 
-func gaugeVersion() string {
+func gaugeVersion(image string) string {
 	return softwareVersion{
 		command:   "gauge --version",
 		trimRegex: `Gauge version: (\d+(.\d+)?(.\d+)?)`,
@@ -46,37 +46,37 @@ Plugins
 html-report (4.0.6)
 js (2.3.4)
 screenshot (0.0.1)`}.
-		findAndTrim()
+		findAndTrim(image)
 }
 
-func chromeVersion() string {
+func chromeVersion(image string) string {
 	return softwareVersion{
 		command:   "google-chrome --version",
 		trimRegex: `Google Chrome ([0|1-9|\.]*)`,
 		dummy:     "Google Chrome 81.0.4044.92"}.
-		findAndTrim()
+		findAndTrim(image)
 }
 
-func goVersion() string {
+func goVersion(image string) string {
 	return softwareVersion{
 		command:   "go version",
 		trimRegex: `go version go(\d+(.\d+)?(.\d+)?)`,
 		dummy:     "go version go1.0.2 darwin/amd64"}.
-		findAndTrim()
+		findAndTrim(image)
 }
 
-func nodeVersion() string {
+func nodeVersion(image string) string {
 	return softwareVersion{
 		command:   "node --version",
 		trimRegex: `v(\d+(.\d+)?(.\d+)?)`,
 		dummy:     "v1.0.3"}.
-		findAndTrim()
+		findAndTrim(image)
 }
 
-func taikoVersion() string {
+func taikoVersion(image string) string {
 	return softwareVersion{
 		command:   "npm ls taiko -global -parseable -long",
 		trimRegex: `taiko@(\d+(.\d+)?(.\d+)?)`,
 		dummy:     "/home/circleci/.npm-global/lib/node_modules/taiko:taiko@1.0.4:undefined"}.
-		findAndTrim()
+		findAndTrim(image)
 }

--- a/magefile.go
+++ b/magefile.go
@@ -6,15 +6,17 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/agilepathway/cimg-gauge/internal/docker"
 )
 
 var Default = DockerTags
 
-// Returns the Docker tags which should be added to the Docker image
+// DockerTags returns the list of Docker tags which the image should then be tagged with.
+// The list includes version numbers of the key software installed on the image.
 func DockerTags() {
 	log.Println("Getting the Docker tags ...")
-
-	fmt.Print(docker.Tags())
+	imageName := os.Getenv("IMAGE_NAME")
+	fmt.Print(docker.TagsForImage(imageName))
 }


### PR DESCRIPTION
Created a new `image` type which gets instantiated with the image name.
Closes #49

Lookup the version numbers just once, when initialising the new image
type.
Closes #47