### PR TITLE
Add misspell check

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -44,3 +44,14 @@ jobs:
           path: "."
           pattern: "*.sh"
           exclude: "./.git/*"
+
+  misspell:
+    name: runner / misspell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-misspell@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          locale: "US"
+          reporter: github-check

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -53,5 +53,4 @@ jobs:
       - uses: reviewdog/action-misspell@v1
         with:
           github_token: ${{ secrets.github_token }}
-          locale: "US"
           reporter: github-check


### PR DESCRIPTION
NB `golangci-lint` is already using `misspell` to check go files for us, but we also want `misspell` to check markdown files too, so this PR adds it as its own GitHub Action.  Keeping the check in `golangci-lint` too, as there's no harm in having any go file spelling errors being reported twice.