### PR TITLE
Lower case tags to match official base images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  docker: agilepathway/docker@0.5.3
+  docker: agilepathway/docker@0.6.0
 
 executors:
   go:

--- a/internal/docker/tags.go
+++ b/internal/docker/tags.go
@@ -42,11 +42,11 @@ func (i image) gaugeVersionAndCircleTag() string {
 }
 
 func (i image) gaugeTag() string {
-	return fmt.Sprintf("GAUGE-%s", i.gaugeVersion)
+	return fmt.Sprintf("gauge-%s", i.gaugeVersion)
 }
 
 func (i image) circleCIBuildTag() string {
-	return fmt.Sprintf("CIRCLECI-%s", i.circleCIBuildNumber())
+	return fmt.Sprintf("circleci-%s", i.circleCIBuildNumber())
 }
 
 func (i image) circleCIBuildNumber() string {
@@ -54,17 +54,17 @@ func (i image) circleCIBuildNumber() string {
 }
 
 func (i image) chromeTag() string {
-	return fmt.Sprintf("CHROME-%s", i.chromeVersion)
+	return fmt.Sprintf("chrome-%s", i.chromeVersion)
 }
 
 func (i image) goTag() string {
-	return fmt.Sprintf("GO-%s", i.goVersion)
+	return fmt.Sprintf("go-%s", i.goVersion)
 }
 
 func (i image) nodeTag() string {
-	return fmt.Sprintf("NODE-%s", i.nodeVersion)
+	return fmt.Sprintf("node-%s", i.nodeVersion)
 }
 
 func (i image) taikoTag() string {
-	return fmt.Sprintf("TAIKO-%s", i.taikoVersion)
+	return fmt.Sprintf("taiko-%s", i.taikoVersion)
 }

--- a/internal/docker/tags_test.go
+++ b/internal/docker/tags_test.go
@@ -13,7 +13,7 @@ func TestTags(t *testing.T) {
 }
 
 func checkDockerTags(t *testing.T, actual []byte) {
-	expectedFormat := `1\.0\.1,1\.0\.1-CIRCLECI-(\d+),GAUGE-1\.0\.1,CHROME-81\.0\.4044\.92,GO-1\.0\.2,NODE-1\.0\.3,TAIKO-1\.0\.4`
+	expectedFormat := `1\.0\.1,1\.0\.1-circleci-(\d+),gauge-1\.0\.1,chrome-81\.0\.4044\.92,go-1\.0\.2,node-1\.0\.3,taiko-1\.0\.4`
 	regex := regexp.MustCompile(expectedFormat)
 
 	if !regex.Match(actual) {

--- a/magefile_test.go
+++ b/magefile_test.go
@@ -24,7 +24,7 @@ func TestDockerTagsMageInvocation(t *testing.T) {
 }
 
 func checkDockerTags(t *testing.T, actual []byte) {
-	expectedFormat := `1\.0\.1,1\.0\.1-CIRCLECI-(\d+),GAUGE-1\.0\.1,CHROME-81\.0\.4044\.92,GO-1\.0\.2,NODE-1\.0\.3,TAIKO-1\.0\.4`
+	expectedFormat := `1\.0\.1,1\.0\.1-circleci-(\d+),gauge-1\.0\.1,chrome-81\.0\.4044\.92,go-1\.0\.2,node-1\.0\.3,taiko-1\.0\.4`
 	regex := regexp.MustCompile(expectedFormat)
 
 	if !regex.Match(actual) {


### PR DESCRIPTION
The official CircleCI image tags are in lower case[1], not upper.  We
should match this, to be consistent.

[1] See the tags for the official CircleCI golang image, for instance:
https://hub.docker.com/r/circleci/golang/tags

Fixes #52